### PR TITLE
chore: add jest v27 to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,6 @@
     "typescript": "^3.9.3"
   },
   "peerDependencies": {
-    "jest": "^26.0.1"
+    "jest": "^26.0.1 || ^27.0.0"
   }
 }


### PR DESCRIPTION
<!--
  We ❤️ Pull Requests!

  Thanks for putting in the work to contribute to this project.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please run prettier and eslint.
  * Please update the documentation where necessary.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

Community guidelines:

- [X] I have read and understand the
      [contributing guidelines](https://github.com/extend-chrome/.github/blob/master/.github/CONTRIBUTING.md)
      and
      [code of conduct](https://github.com/extend-chrome/.github/blob/master/.github/CODE_OF_CONDUCT.md)

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [X] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [X] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [X] no

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Current `jest-chrome` works with jest v27 but yarn/npm throws a warning about incorrect peer dependency.

This PR includes recent jest v27 in peer dependencies, so both v26 and v27 are valid.