### PR TITLE
add missing chrome.tabs.remove function

### DIFF
--- a/src/jest-chrome.d.ts
+++ b/src/jest-chrome.d.ts
@@ -9346,6 +9346,7 @@ export namespace Tabs {
    *
    * @param tabId The tab to close.
    */
+  export const remove: jest.MockedFunction<typeof chrome.tabs.remove>
 
   /**
    * Captures the visible area of the currently active tab in the specified window. You must have <all_urls> permission to use this method.


### PR DESCRIPTION
<!--
  We ❤️ Pull Requests!

  Thanks for putting in the work to contribute to this project.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please run prettier and eslint.
  * Please update the documentation where necessary.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

Community guidelines:

- [x] I have read and understand the
      [contributing guidelines](https://github.com/extend-chrome/.github/blob/master/.github/CONTRIBUTING.md)
      and
      [code of conduct](https://github.com/extend-chrome/.github/blob/master/.github/CODE_OF_CONDUCT.md)

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
[Type is missing for chrome.tabs.remove method](https://github.com/extend-chrome/jest-chrome/issues/15)
### Description

the `.remove` function is missing from `chrome.tabs`.
its already have a comment describing it but the line following it is empty.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
