### PR TITLE
chore: add a prepare step so that git dependencies build

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "jest-chrome.d.ts"
   ],
   "scripts": {
+    "prepare": "run-s build",
     "build": "run-s build:clean build:pro build:types build:copy",
     "build:clean": "rm -rf lib types",
     "build:copy": "copyfiles -f src/jest-chrome.d.ts types",


### PR DESCRIPTION
Community guidelines:

- [x] I have read and understand the
      [contributing guidelines](https://github.com/extend-chrome/.github/blob/master/.github/CONTRIBUTING.md)
      and
      [code of conduct](https://github.com/extend-chrome/.github/blob/master/.github/CODE_OF_CONDUCT.md)

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers: none

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

It is convenient to be able to specify dependencies in `package.json` which point to particular git commits.  One use case is allowing dependencies on PRs which are not yet merged and published to npm.org.

In theory this should be achievable via:

    "jest-chrome": "extend-chrome/vitest-chrome#some-PR-branch-name"

https://docs.npmjs.com/cli/v8/configuring-npm/package-json#git-urls-as-dependencies states:

> When installing from a git repository, the presence of certain fields in the package.json will cause npm to believe it needs to perform a build. To do so your repository will be cloned into a temporary directory, all of its deps installed, relevant scripts run, and the resulting directory packed and installed.
>
> This flow will occur if your git dependency uses workspaces, or if any of the following scripts are present:
>
> - `build`
> - `prepare`
> - `prepack`
> - `preinstall`
> - `install`
> - `postinstall`

And indeed jest-chrome already has a `build` script.

However it seems that, at least with pnpm, the presence of a `build` script is not sufficient.

So add a `prepare` script which just dispatches to the `build` script. This makes jest-chrome installable via a git dependency.

See also https://github.com/probil/vitest-chrome/pull/2

